### PR TITLE
Fixes/esys pipeline data deps workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
   `mluk_bb_field_block_cadastre` for PV ground potential calculation
 
 ### Fixed
+
+- Dependencies for esys input data added: upstream rules are now triggered when
+  executing `make_esys_appdata`

--- a/apipe/esys/scripts/create_empty_ts.py
+++ b/apipe/esys/scripts/create_empty_ts.py
@@ -33,10 +33,7 @@ from oemoflex.model.model_structure import module_path
 from apipe.esys.esys import model
 from apipe.esys.esys.config.esys_conf import load_yaml, settings
 from apipe.esys.esys.model import model_structures
-from apipe.esys.esys.tools.data_processing import (
-    HEADER_B3_TS,
-    stack_timeseries,
-)
+from apipe.esys.esys.tools.data_processing import HEADER_B3_TS, stack_timeseries
 
 
 def get_sub_dict(subsub_key, _dict):

--- a/apipe/esys/snakemake_rules/write_ts.smk
+++ b/apipe/esys/snakemake_rules/write_ts.smk
@@ -1,10 +1,22 @@
+from apipe.esys.esys.config.esys_conf import map_ts
+from apipe.store.utils import get_abs_dataset_path
+
+
 rule write_ts:
     input:
-        "store/datasets/esys_raw/data/time_series/empty_ts_efficiencies.csv",
-        "store/datasets/esys_raw/data/time_series/empty_ts_feedin.csv",
-        "store/datasets/esys_raw/data/time_series/empty_ts_load.csv",
+        eff="store/datasets/esys_raw/data/time_series/empty_ts_efficiencies.csv",
+        feedin="store/datasets/esys_raw/data/time_series/empty_ts_feedin.csv",
+        load="store/datasets/esys_raw/data/time_series/empty_ts_load.csv",
+        file_mapping_dummy=[  # Workaround to include data from pipeline
+            [get_abs_dataset_path("datasets", d["dataset"]) / "data"/ d["file"]
+             for d in map_ts[c].values()]
+            for c in ["load", "feedin", "efficiencies"]
+        ]
     output:
         "store/datasets/esys_raw/data/time_series/ts_efficiencies.csv",
         "store/datasets/esys_raw/data/time_series/ts_feedin.csv",
         "store/datasets/esys_raw/data/time_series/ts_load.csv",
-    shell: "python esys/scripts/write_ts.py {input} {output}"
+    shell:
+        """
+        python esys/scripts/write_ts.py {input.eff} {input.feedin} {input.load} {output}
+        """

--- a/apipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
@@ -3,11 +3,7 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
 from apipe.store.utils import (
     PATH_TO_REGION_DISTRICTS_GPKG,
     df_merge_string_columns,

--- a/apipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:

--- a/apipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
+++ b/apipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
@@ -3,15 +3,8 @@ import pandas as pd
 
 from apipe.config import GLOBAL_CONFIG
 from apipe.scripts.datasets import mastr
-from apipe.scripts.geo import (
-    overlay,
-    rename_filter_attributes,
-    write_geofile,
-)
-from apipe.store.utils import (
-    PATH_TO_REGION_DISTRICTS_GPKG,
-    get_names_from_nuts,
-)
+from apipe.scripts.geo import overlay, rename_filter_attributes, write_geofile
+from apipe.store.utils import PATH_TO_REGION_DISTRICTS_GPKG, get_names_from_nuts
 
 
 def process() -> None:


### PR DESCRIPTION
Dependencies for esys input data added: upstream rules are now triggered when executing `make_esys_appdata`

## Before merging into `dev`-branch, please make sure that the following points are checked:

- [x] All pre-commit tests passed locally with: `pre-commit run -a`
- [x] File `CHANGELOG.md` was updated
- [ ] The docs were updated
  - [ ] if `dataset.md`s were updated, the dataset docs were regenerated using
    `python docs/generate_dataset_mds.py`

If packages were modified:
- [ ] File `poetry.lock` was updated with: `poetry lock`
- [ ] A new env was successfully set up

WARNING: When modifying use snakemake <=7.32.0, cf. #186

If data flow was adjusted:
- [ ] Data pipeline run finished successfully with: `snakemake -jX`
- [x] Esys appdata was created successfully with: `snakemake -jX make_esys_appdata`

  (with `X` =  desired number of cores, e.g. 1)
