### PR TITLE
Sle features/improve esys md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 
 - Dependencies for esys input data added: upstream rules are now triggered when
   executing `make_esys_appdata`
+- Documentation for executing `make_esys_appdata` has been adapted accordingly

--- a/apipe/esys/ESYS.md
+++ b/apipe/esys/ESYS.md
@@ -11,12 +11,17 @@ To test if everything works, you can run the test scenario with
 snakemake -j1 make_esys_appdata
 ```
 
-For this you have to copy the corresponding raw data from into the raw directory
-`store/esys_raw/`.
-In the future, empty raw data (scalars and time series) will be created
-automatically. Then, assumptions on constant parameters such as plant costs,
-lifetime and efficiencies are mapped and set as values of the corresponding
-variables in the scalars.
+For this you have to provide the corresponding input data in the store:
+
+- raw/technology_data/data
+- raw/renewables.ninja_feedin/data
+- raw/demandregio/data
+- raw/bkg_vg250/data
+- raw/dwd_temperature/data.
+
+Then, assumptions on constant parameters such as plant costs, lifetime and
+efficiencies are mapped and set as values of the corresponding variables in the
+scalars.
 
 Empty scalars and time series can be created from the energy model setup with
 


### PR DESCRIPTION
With this PR the documentation on executing the `make_esys_appdata` rule is fixed.

## Before merging into `dev`-branch, please make sure that the following points are checked:

- ~[ ] All pre-commit tests passed locally with: `pre-commit run -a`~
- [x] File `CHANGELOG.md` was updated
- [x] The docs were updated
  - ~[ ] if `dataset.md`s were updated, the dataset docs were regenerated using~
    ~`python docs/generate_dataset_mds.py`~

If packages were modified:
- ~[ ] File `poetry.lock` was updated with: `poetry lock`~
- ~[ ] A new env was successfully set up~

WARNING: When modifying use snakemake <=7.32.0, cf. #186

If data flow was adjusted:
- ~[ ] Data pipeline run finished successfully with: `snakemake -jX`~
- ~[ ] Esys appdata was created successfully with: `snakemake -jX make_esys_appdata`~

  (with `X` =  desired number of cores, e.g. 1)
